### PR TITLE
jenkins-job.sh: run_prepare: Fix packagegroup-meta-multimedia.bb RDEP…

### DIFF
--- a/jenkins-job.sh
+++ b/jenkins-job.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUILD_SCRIPT_VERSION="1.8.45"
+BUILD_SCRIPT_VERSION="1.8.46"
 BUILD_SCRIPT_NAME=`basename ${0}`
 SRCMIRROR="10.20.9.193"
 LOGMIRROR="10.20.9.193"
@@ -377,8 +377,8 @@ PNBLACKLIST[android-system] = "depends on lxc from meta-virtualiazation which is
 PNBLACKLIST[bigbuckbunny-1080p] = "big and doesn't really need to be tested so much"
 PNBLACKLIST[bigbuckbunny-480p] = "big and doesn't really need to be tested so much"
 PNBLACKLIST[bigbuckbunny-720p] = "big and doesn't really need to be tested so much"
-PNBLACKLIST[bigbuckbunny-720p] = "big and doesn't really need to be tested so much"
 PNBLACKLIST[tearsofsteel-1080p] = "big and doesn't really need to be tested so much"
+RDEPENDS_packagegroup-meta-multimedia_remove_pn-packagegroup-meta-multimedia = "bigbuckbunny-1080p bigbuckbunny-480p bigbuckbunny-720p tearsofsteel-1080p"
 PNBLACKLIST[build-appliance-image] = "tries to include whole downloads directory in /home/builder/poky :/"
 PNBLACKLIST[smartrefrigerator] = "Needs porting to QT > 5.6"
 PNBLACKLIST[qmlbrowser] = "Needs porting to QT > 5.6"


### PR DESCRIPTION
…ENDS to match our PNBLACKLIST (v1.8.46)

* fixes:
  http://logs.nslu2-linux.org/buildlogs/oe/world/warrior/log.world.qemux86.20190811_145632.log/bitbake.log
  ERROR: Nothing RPROVIDES 'tearsofsteel-1080p' (but /home/jenkins/oe/world/yoe/sources/meta-openembedded/meta-multimedia/recipes-multimedia/packagegroups/packagegroup-meta-multimedia.bb RDEPENDS on or otherwise requires it)
  tearsofsteel-1080p was skipped: Recipe is blacklisted: big and doesn't really need to be tested so much
  NOTE: Runtime target 'tearsofsteel-1080p' is unbuildable, removing...
  Missing or unbuildable dependency chain was: ['tearsofsteel-1080p']
  ERROR: Nothing RPROVIDES 'bigbuckbunny-480p' (but /home/jenkins/oe/world/yoe/sources/meta-openembedded/meta-multimedia/recipes-multimedia/packagegroups/packagegroup-meta-multimedia.bb RDEPENDS on or otherwise requires it)
  bigbuckbunny-480p was skipped: Recipe is blacklisted: big and doesn't really need to be tested so much
  NOTE: Runtime target 'bigbuckbunny-480p' is unbuildable, removing...
  Missing or unbuildable dependency chain was: ['bigbuckbunny-480p']
  ERROR: Nothing RPROVIDES 'bigbuckbunny-720p' (but /home/jenkins/oe/world/yoe/sources/meta-openembedded/meta-multimedia/recipes-multimedia/packagegroups/packagegroup-meta-multimedia.bb RDEPENDS on or otherwise requires it)
  bigbuckbunny-720p was skipped: Recipe is blacklisted: big and doesn't really need to be tested so much
  NOTE: Runtime target 'bigbuckbunny-720p' is unbuildable, removing...
  Missing or unbuildable dependency chain was: ['bigbuckbunny-720p']
  ERROR: Nothing RPROVIDES 'packagegroup-meta-multimedia' (but /home/jenkins/oe/world/yoe/sources/meta-openembedded/meta-multimedia/recipes-multimedia/packagegroups/packagegroup-meta-multimedia.bb RDEPENDS on or otherwise requires it)
  No eligible RPROVIDERs exist for 'packagegroup-meta-multimedia'
  NOTE: Runtime target 'packagegroup-meta-multimedia' is unbuildable, removing...
  Missing or unbuildable dependency chain was: ['packagegroup-meta-multimedia']
  ERROR: Nothing RPROVIDES 'bigbuckbunny-1080p' (but /home/jenkins/oe/world/yoe/sources/meta-openembedded/meta-multimedia/recipes-multimedia/packagegroups/packagegroup-meta-multimedia.bb RDEPENDS on or otherwise requires it)
  bigbuckbunny-1080p was skipped: Recipe is blacklisted: big and doesn't really need to be tested so much
  NOTE: Runtime target 'bigbuckbunny-1080p' is unbuildable, removing...
  Missing or unbuildable dependency chain was: ['bigbuckbunny-1080p']

* should help with:
  http://jenkins.nas-admin.org/view/OE/job/oe_world_workspace-compare-signatures/683/console
  as well (unless there are more issues shown in next run)

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>