### PR TITLE
Lowered Parallel Make to attempt to make builder not be overloaded

### DIFF
--- a/jenkins-job.sh
+++ b/jenkins-job.sh
@@ -294,7 +294,7 @@ TCLIBCAPPEND = "fs"
 TMPDIR .= "fs"
 DL_DIR = "${BUILD_TOPDIR}/../downloads"
 
-PARALLEL_MAKE_append = " -l \${@int(os.sysconf(os.sysconf_names['SC_NPROCESSORS_ONLN'])) * 150/100}"
+PARALLEL_MAKE_append = " -l \${@int(os.sysconf(os.sysconf_names['SC_NPROCESSORS_ONLN']))}"
 INHERIT += "rm_work"
 
 # For kernel-selftest with linux 4.18+


### PR DESCRIPTION
(JUST A TEST)

The builder is having issues related to excessive Parallel Makes (50% overloaded and reporting issues).

This is an attempt to maximize without overloading.